### PR TITLE
Update blck_init.sqf

### DIFF
--- a/@epochhive/addons/custom_server/init/blck_init.sqf
+++ b/@epochhive/addons/custom_server/init/blck_init.sqf
@@ -111,8 +111,8 @@ if (blck_enableBlueMissions > 0) then
 };
 
 //  start the main thread for the mission system which monitors missions running and stuff to be cleaned up
-[] execVM "\q\addons\custom_server\Compiles\Functions\GMS_fnc_mainThread.sqf";
-[] execVM "\q\addons\custom_server\Compiles\Vehicles\GMS_fnc_vehicleMonitorLoop.sqf";
+call compile preprocessfilelinenumber "\q\addons\custom_server\Compiles\Functions\GMS_fnc_mainThread.sqf";
+call compile preprocessfilelinenumber "\q\addons\custom_server\Compiles\Vehicles\GMS_fnc_vehicleMonitorLoop.sqf";
 
 // start a little loop that sends clients the current serverFPS
 [] execVM "\q\addons\custom_server\Compiles\Functions\broadcastServerFPS.sqf";


### PR DESCRIPTION
Lines 114 and 114 can be compiled to save server threads, it didn't pv blck_Initialized but missions still ran as intended with 50% less server threads