### PR TITLE
Update initPlayerLocal.sqf

### DIFF
--- a/MPMissions/epoch.Altis/initPlayerLocal.sqf
+++ b/MPMissions/epoch.Altis/initPlayerLocal.sqf
@@ -1,1 +1,1 @@
-call compile preprocessfilelinenumbers "debug\blckClient.sqf";
+execVM "debug\blckClient.sqf";


### PR DESCRIPTION
Depending on end users mission file structure, not execVM'ing this could stall any later listed features, so it's safer to have it as this, it won't effect server threads