### PR TITLE
Prevent dead cleanup and script fix

### DIFF
--- a/@GMS/addons/custom_server/Compiles/Units/GMS_fnc_cleanupAliveAI.sqf
+++ b/@GMS/addons/custom_server/Compiles/Units/GMS_fnc_cleanupAliveAI.sqf
@@ -37,31 +37,24 @@ for "_i" from 1 to (count blck_liveMissionAI) do
 {
 	if ((_i) <= count blck_liveMissionAI) then
 	{
-		_units = blck_liveMissionAI select (_i - 1);
-		//diag_log format["_fnc_cleanupAliveAI:: (34) evaluating with delete time = %2 and diag_tickTime %1", diag_tickTime, _units select 1];
-		if (diag_tickTime > (_units select 1) ) then
-		{
-			//diag_log format["_fnc_cleanupAliveAI:: cleaning up AI group %1",_units];
+		_units = blck_liveMissionAI deleteat 0;
+		_units params ["_unitsarr","_timer"];
+		if (diag_tickTime > _timer) then {
 			{
-			
-				//diag_log format["_fnc_cleanupAliveAI:: deleting unit %1",_x];
-				//diag_log format["_fnc_cleanupAliveAI:: vehicle _x = %1",vehicle _x];
-				//diag_log format["_fnc_cleanupAliveAI:: objectParent _x = %1",objectParent _x];
-				
-				if ((alive _x) && !(isNull objectParent _x)) then // mark the vehicle for deletion
-				{
-					//diag_log format["_fnc_cleanupAliveAI: deleteing objectParent %1 [%3] for unit %2",objectParent _x, _x, typeName (objectParent _x), typeOf (objectParent _x)];
-					[objectParent _x] call blck_fnc_deleteAIvehicle;
+				if (alive _x) then {
+					if (!isNull objectParent _x) then {
+						[objectParent _x] call blck_fnc_deleteAIvehicle;
+					};
+					[_x] call blck_fnc_deleteAI;
 				};
-				[_x] call blck_fnc_deleteAI;
-			}forEach (_units select 0);
+			} forEach _unitsarr;
 			uiSleep 0.1;
-			blck_liveMissionAI set[(_i - 1), -1];
-			blck_liveMissionAI = blck_liveMissionAI - [-1];  // Remove that list of live AI from the list.
-
 			#ifdef blck_debugMode
 			if (blck_debugLevel > 1) then {diag_log format["_fnc_mainTread:: blck_liveMissionAI updated to %1",blck_liveMissionAI];};
 			#endif
+		}
+		else {
+			blck_liveMissionAI pushback _units;
 		};
 	};
 };


### PR DESCRIPTION
1. Using "_units = blck_liveMissionAI select (_i - 1);" could cause undefined behaviour if removing entries from array inside this loop.
So always deleteat 0, but pushback if delete is not wanted / needed
2. Check first, if the AI is dead. If so, skip cleanup, so players can loot the corpse