### PR TITLE
Pole Check fix

### DIFF
--- a/@GMS/addons/custom_server/Compiles/Functions/GMS_fnc_findSafePosn.sqf
+++ b/@GMS/addons/custom_server/Compiles/Functions/GMS_fnc_findSafePosn.sqf
@@ -73,7 +73,7 @@ while {_findNew} do
 			{
 				_findNew = true;
 			};
-		}forEach  nearestObjects[blck_mapCenter, [_pole], blck_minDistanceToBases];		
+		}forEach (allmissionobjects _pole);		
 	};		
 	if !(_findNew) then
 	{


### PR DESCRIPTION
"nearestObjects[blck_mapCenter, [_pole], blck_minDistanceToBases]" only checks on mapcenter with blck_minDistanceToBases radius.