### PR TITLE
Update GMS_fnc_spawnUnit.sqf

### DIFF
--- a/@GMS/addons/custom_server/Compiles/Units/GMS_fnc_spawnUnit.sqf
+++ b/@GMS/addons/custom_server/Compiles/Units/GMS_fnc_spawnUnit.sqf
@@ -91,10 +91,10 @@ _ammoChoices = getArray (configFile >> "CfgWeapons" >> _weap >> "magazines");
 _unit addMagazines[selectRandom _ammochoices,3];
 
 // more compatibel way to check for attachments
-_muzzles = [_weap, "muzzle"] call CBA_fnc_compatibleItems;
-_optics = [_weap, "optic"] call CBA_fnc_compatibleItems;   
-_pointers = [_weap, "pointer"] call CBA_fnc_compatibleItems;
-_underbarrel = [_weap, "bipod"] call CBA_fnc_compatibleItems;
+_muzzles = [_weap, 101] call BIS_fnc_compatibleItems;
+_optics = [_weap, 201] call BIS_fnc_compatibleItems;
+_pointers = [_weap, 301] call BIS_fnc_compatibleItems;
+_underbarrel = [_weap, 302] call BIS_fnc_compatibleItems;
 
 /*
 _optics = getArray (configfile >> "CfgWeapons" >> _weap >> "WeaponSlotsInfo" >> "CowsSlot" >> "compatibleItems");

--- a/@GMS/addons/custom_server/Compiles/Units/GMS_fnc_spawnUnit.sqf
+++ b/@GMS/addons/custom_server/Compiles/Units/GMS_fnc_spawnUnit.sqf
@@ -89,11 +89,19 @@ _weap = selectRandom _weaponList;
 _unit addWeaponGlobal  _weap; 
 _ammoChoices = getArray (configFile >> "CfgWeapons" >> _weap >> "magazines");
 _unit addMagazines[selectRandom _ammochoices,3];
+
+// more compatibel way to check for attachments
+_muzzles = [_weap, "muzzle"] call CBA_fnc_compatibleItems;
+_optics = [_weap, "optic"] call CBA_fnc_compatibleItems;   
+_pointers = [_weap, "pointer"] call CBA_fnc_compatibleItems;
+_underbarrel = [_weap, "bipod"] call CBA_fnc_compatibleItems;
+
+/*
 _optics = getArray (configfile >> "CfgWeapons" >> _weap >> "WeaponSlotsInfo" >> "CowsSlot" >> "compatibleItems");
 _pointers = getArray (configFile >> "CfgWeapons" >> _weap >> "WeaponSlotsInfo" >> "PointerSlot" >> "compatibleItems");
 _muzzles = getArray (configFile >> "CfgWeapons" >> _weap >> "WeaponSlotsInfo" >> "MuzzleSlot" >> "compatibleItems");
 _underbarrel = getArray (configFile >> "CfgWeapons" >> _weap >> "WeaponSlotsInfo" >> "UnderBarrelSlot" >> "compatibleItems");
-
+*/
 
 
 if (random 1 < 0.4) then {_unit addPrimaryWeaponItem (selectRandom _muzzles)};


### PR DESCRIPTION
Issue : Npc spawns without optics / underbarrel / pointer attachments when CBA is running on server.

Fix : use more compatibel code to find attachments.
use
_pointers = [_weap, 301] call BIS_fnc_compatibleItems;
Instead of :
_pointers = getArray (configFile >> "CfgWeapons" >> _weap >> "WeaponSlotsInfo" >> "PointerSlot" >> "compatibleItems");

_muzzles = [_weap, 101] call BIS_fnc_compatibleItems;
_optics = [_weap, 201] call BIS_fnc_compatibleItems;
_pointers = [_weap, 301] call BIS_fnc_compatibleItems;
_underbarrel = [_weap, 302] call BIS_fnc_compatibleItems;